### PR TITLE
Prevent XSS in shortchode

### DIFF
--- a/wp-gratipay/wp-gratipay.php
+++ b/wp-gratipay/wp-gratipay.php
@@ -28,7 +28,7 @@ function wp_gratipay_shortcode($atts) {
 			'username' => '',
 		), $atts);
 
-	return '<script data-gratipay-username="' . $atts['username'] .'" src="//grtp.co/v1.js"></script>';
+	return '<script data-gratipay-username="' . htmlspecialchars($atts['username']) .'" src="//grtp.co/v1.js"></script>';
 
 }
 


### PR DESCRIPTION
The variable `$atts` is not escaped before returning it so it's vulnerable to XSS.. I've used `htmlspecialchars()` to prevent it.
